### PR TITLE
fix printing of duration for LSB_OUTPUT_FORMAT=efficient

### DIFF
--- a/liblsb.cpp
+++ b/liblsb.cpp
@@ -522,7 +522,7 @@ void LSB_Flush() {
 
 
       fprintf(fp, "%i ", lsb_data->recs[i].id);
-      fprintf(fp, "%llu ", lsb_data->recs[i].tduration);
+      fprintf(fp, "%f ", lsb_data->recs[i].tduration);
       fprintf(fp, "%lu ", lsb_data->recs[i].toverhead);
      
 


### PR DESCRIPTION
For efficient output format, duration was being printed as unsigned long long
rather than double, which resulted in garbage output. Fixed to print as double.